### PR TITLE
Обрезать ".0" для текстовых полей, содержащих число

### DIFF
--- a/src/main/java/org/spacious_team/table_wrapper/excel/ExcelCellDataAccessObject.java
+++ b/src/main/java/org/spacious_team/table_wrapper/excel/ExcelCellDataAccessObject.java
@@ -48,6 +48,16 @@ public class ExcelCellDataAccessObject implements CellDataAccessObject<Cell, Exc
     }
 
     @Override
+    public String getStringValue(Cell cell) {
+        Object value = getValue(cell);
+        String strValue = value.toString();
+        if ((value instanceof Number) && strValue.endsWith(".0")) {
+            return strValue.substring(0, strValue.length() - 2);
+        }
+        return strValue;
+    }
+
+    @Override
     public Instant getInstantValue(Cell cell) {
         return cell.getDateCellValue().toInstant();
     }


### PR DESCRIPTION
Если ячейка с форматом "Общий" содержит число, например, `1`, то getStringValue() возвращает `"1.0"`. Нужно обрезать окончание `".0"`.